### PR TITLE
Run sequelize migrations with error handling

### DIFF
--- a/backend/migrations/20250101000050-alter-orders-add-status-discount-coupon.js
+++ b/backend/migrations/20250101000050-alter-orders-add-status-discount-coupon.js
@@ -42,8 +42,6 @@ module.exports = {
       await queryInterface.removeColumn('orders', 'status');
     }
 
-    if (queryInterface.sequelize.getDialect() === 'postgres') {
-      await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_orders_status"');
-    }
+
   }
 };

--- a/backend/migrations/20250101000050-alter-orders-add-status-discount-coupon.js
+++ b/backend/migrations/20250101000050-alter-orders-add-status-discount-coupon.js
@@ -41,7 +41,5 @@ module.exports = {
     if (table.status) {
       await queryInterface.removeColumn('orders', 'status');
     }
-
-
   }
 };

--- a/backend/migrations/20250101000050-alter-orders-add-status-discount-coupon.js
+++ b/backend/migrations/20250101000050-alter-orders-add-status-discount-coupon.js
@@ -2,14 +2,48 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('orders', 'status', { type: Sequelize.ENUM('draft','submitted','cancelled'), allowNull: false, defaultValue: 'draft' });
-    await queryInterface.addColumn('orders', 'discount', { type: Sequelize.DECIMAL(10,2), allowNull: false, defaultValue: 0 });
-    await queryInterface.addColumn('orders', 'coupon_code', { type: Sequelize.STRING, allowNull: true });
+    const table = await queryInterface.describeTable('orders');
+
+    if (!table.status) {
+      await queryInterface.addColumn('orders', 'status', {
+        type: Sequelize.ENUM('draft', 'submitted', 'cancelled'),
+        allowNull: false,
+        defaultValue: 'draft',
+      });
+    }
+
+    if (!table.discount) {
+      await queryInterface.addColumn('orders', 'discount', {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: false,
+        defaultValue: 0,
+      });
+    }
+
+    if (!table.coupon_code) {
+      await queryInterface.addColumn('orders', 'coupon_code', {
+        type: Sequelize.STRING,
+        allowNull: true,
+      });
+    }
   },
   async down(queryInterface, Sequelize) {
-    await queryInterface.removeColumn('orders', 'coupon_code');
-    await queryInterface.removeColumn('orders', 'discount');
-    await queryInterface.removeColumn('orders', 'status');
-    await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_orders_status"');
+    const table = await queryInterface.describeTable('orders');
+
+    if (table.coupon_code) {
+      await queryInterface.removeColumn('orders', 'coupon_code');
+    }
+
+    if (table.discount) {
+      await queryInterface.removeColumn('orders', 'discount');
+    }
+
+    if (table.status) {
+      await queryInterface.removeColumn('orders', 'status');
+    }
+
+    if (queryInterface.sequelize.getDialect() === 'postgres') {
+      await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_orders_status"');
+    }
   }
 };


### PR DESCRIPTION
Make `alter-orders-add-status-discount-coupon` migration idempotent and MySQL-only to prevent duplicate column errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a74f526-772e-4b61-b348-6e93497429b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a74f526-772e-4b61-b348-6e93497429b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

