### PR TITLE
Handle backend address resolution errors

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const target = process.env.VITE_PROXY_TARGET || 'http://backend:4000'
+const target = process.env.VITE_PROXY_TARGET || 'http://localhost:4000'
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Default Vite proxy target to localhost to fix DNS resolution errors when running locally without Docker.

---
<a href="https://cursor.com/background-agent?bcId=bc-b494ecf6-b9c0-4b57-8d7d-e5ed3ac9227d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b494ecf6-b9c0-4b57-8d7d-e5ed3ac9227d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

